### PR TITLE
Add tabletop RPG module with characters, battles, and missions

### DIFF
--- a/alura_receitas/settings.py
+++ b/alura_receitas/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'receitas',
     'pessoas',
     'users',
+    'rpg',
 ]
 
 MIDDLEWARE = [

--- a/alura_receitas/static/rpg.css
+++ b/alura_receitas/static/rpg.css
@@ -1,0 +1,186 @@
+.rpg-hero {
+  background: linear-gradient(120deg, #3b1454, #1f2955);
+  color: #fff;
+  padding: 60px 0;
+  text-align: center;
+}
+
+.rpg-hero h1 {
+  font-size: 2.8rem;
+  margin-bottom: 10px;
+}
+
+.rpg-hero p {
+  max-width: 720px;
+  margin: 0 auto 20px;
+  font-size: 1.1rem;
+}
+
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.rpg-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.rpg-btn {
+  display: inline-block;
+  background: #f7b733;
+  color: #1d1b31;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rpg-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  color: #1d1b31;
+}
+
+.rpg-section {
+  padding: 48px 0;
+}
+
+.rpg-section.alt {
+  background: #f5f5f7;
+}
+
+.rpg-section h2,
+.rpg-section h1 {
+  margin-bottom: 16px;
+}
+
+.rpg-muted {
+  color: #6b6f7b;
+}
+
+.rpg-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.rpg-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 15px 30px rgba(15, 25, 40, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rpg-link,
+.rpg-inline-link {
+  color: #5c3aff;
+  font-weight: 600;
+}
+
+.rpg-inline-link {
+  margin-left: 8px;
+}
+
+.rpg-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.rpg-split {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 768px) {
+  .rpg-split {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.rpg-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+@media (min-width: 768px) {
+  .rpg-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.rpg-form {
+  margin-top: 24px;
+  background: #fff;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 15px 30px rgba(15, 25, 40, 0.08);
+}
+
+.rpg-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.rpg-field label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.rpg-field input,
+.rpg-field textarea,
+.rpg-field select {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #d6d9e3;
+  background: #fafbff;
+  font-size: 1rem;
+}
+
+.rpg-field textarea {
+  resize: vertical;
+}
+
+.rpg-error {
+  margin-top: 4px;
+  color: #b00020;
+  font-size: 0.9rem;
+}
+
+.rpg-attributes {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.rpg-attributes li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rpg-attributes strong {
+  font-weight: 600;
+}

--- a/alura_receitas/urls.py
+++ b/alura_receitas/urls.py
@@ -23,5 +23,6 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('', include('receitas.urls')),
     path('users/', include('users.urls')),
+    path('rpg/', include('rpg.urls')),
     path('admin/', admin.site.urls),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/rpg/admin.py
+++ b/rpg/admin.py
@@ -1,0 +1,56 @@
+"""Admin registrations for the RPG application."""
+
+# Django
+from django.contrib import admin
+
+# Local
+from .models import Battle, Character, Mission, MissionAttempt, TrainingBot
+
+
+@admin.register(Character)
+class CharacterAdmin(admin.ModelAdmin):
+    list_display = (
+        'name',
+        'archetype',
+        'level',
+        'experience',
+        'gold',
+        'owner',
+        'created_at',
+    )
+    search_fields = ('name', 'archetype', 'owner__username')
+    list_filter = ('archetype', 'level')
+
+
+@admin.register(Mission)
+class MissionAdmin(admin.ModelAdmin):
+    list_display = ('name', 'difficulty', 'minimum_level', 'experience_reward', 'gold_reward')
+    search_fields = ('name',)
+    list_filter = ('difficulty',)
+
+
+@admin.register(MissionAttempt)
+class MissionAttemptAdmin(admin.ModelAdmin):
+    list_display = ('mission', 'character', 'success', 'experience_earned', 'created_at')
+    list_filter = ('success', 'mission__difficulty')
+    search_fields = ('mission__name', 'character__name')
+
+
+@admin.register(TrainingBot)
+class TrainingBotAdmin(admin.ModelAdmin):
+    list_display = ('name', 'power_rating', 'experience_reward', 'gold_reward')
+    search_fields = ('name',)
+
+
+@admin.register(Battle)
+class BattleAdmin(admin.ModelAdmin):
+    list_display = (
+        'challenger',
+        'opponent',
+        'bot',
+        'winner',
+        'is_training',
+        'created_at',
+    )
+    list_filter = ('is_training', 'winner')
+    search_fields = ('challenger__name', 'opponent__name', 'bot__name')

--- a/rpg/apps.py
+++ b/rpg/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class RpgConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'rpg'
+    verbose_name = 'Aventura de Mesa Online'

--- a/rpg/forms.py
+++ b/rpg/forms.py
@@ -1,0 +1,83 @@
+"""Forms used for managing RPG interactions."""
+
+# Django
+from django import forms
+
+# Local
+from .models import Character, Mission, TrainingBot
+
+
+class CharacterForm(forms.ModelForm):
+    class Meta:
+        model = Character
+        fields = [
+            'name',
+            'concept',
+            'origin',
+            'archetype',
+            'strength',
+            'agility',
+            'intellect',
+            'spirit',
+            'vitality',
+            'hit_points',
+            'mana',
+            'biography',
+        ]
+        widgets = {
+            'biography': forms.Textarea(attrs={'rows': 4}),
+        }
+
+
+class DuelForm(forms.Form):
+    challenger = forms.ModelChoiceField(
+        queryset=Character.objects.all(),
+        label='Seu personagem',
+        help_text='Escolha o herói que desafiará o adversário.',
+    )
+    opponent = forms.ModelChoiceField(
+        queryset=Character.objects.all(),
+        label='Oponente',
+        help_text='Selecione contra quem batalhar.',
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        challenger = cleaned_data.get('challenger')
+        opponent = cleaned_data.get('opponent')
+        if challenger and opponent and challenger == opponent:
+            raise forms.ValidationError('Escolha personagens diferentes para o duelo.')
+        return cleaned_data
+
+
+class MissionAttemptForm(forms.Form):
+    character = forms.ModelChoiceField(
+        queryset=Character.objects.all(),
+        label='Personagem',
+    )
+
+    def __init__(self, mission: Mission, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mission = mission
+        self.fields['character'].queryset = Character.objects.filter(level__gte=mission.minimum_level)
+        self.fields['character'].help_text = (
+            f"Disponível para aventureiros a partir do nível {mission.minimum_level}."
+        )
+
+
+class TrainingBattleForm(forms.Form):
+    character = forms.ModelChoiceField(
+        queryset=Character.objects.all(),
+        label='Personagem',
+    )
+    bot = forms.ModelChoiceField(queryset=TrainingBot.objects.all(), label='Autômato')
+
+    def clean(self):
+        cleaned_data = super().clean()
+        character = cleaned_data.get('character')
+        bot = cleaned_data.get('bot')
+        if character and bot and character.level * 10 < bot.power_rating * 5:
+            raise forms.ValidationError(
+                'Este desafio é muito difícil! Evolua mais um pouco antes de enfrentar este autômato.'
+            )
+        return cleaned_data

--- a/rpg/migrations/0001_initial.py
+++ b/rpg/migrations/0001_initial.py
@@ -1,0 +1,117 @@
+# Generated manually to introduce the RPG game models.
+
+# Django
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Character',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=120, verbose_name='Nome')),
+                ('concept', models.CharField(help_text='Resumo rápido do personagem.', max_length=120, verbose_name='Conceito')),
+                ('origin', models.CharField(blank=True, help_text='Cidade, clã ou organização.', max_length=120, verbose_name='Origem')),
+                ('archetype', models.CharField(help_text='Classe ou função dentro do grupo.', max_length=80, verbose_name='Arquétipo')),
+                ('strength', models.PositiveIntegerField(default=1, verbose_name='Força')),
+                ('agility', models.PositiveIntegerField(default=1, verbose_name='Agilidade')),
+                ('intellect', models.PositiveIntegerField(default=1, verbose_name='Intelecto')),
+                ('spirit', models.PositiveIntegerField(default=1, verbose_name='Espírito')),
+                ('vitality', models.PositiveIntegerField(default=1, verbose_name='Vitalidade')),
+                ('experience', models.PositiveIntegerField(default=0, verbose_name='Experiência')),
+                ('gold', models.PositiveIntegerField(default=0, verbose_name='Ouro')),
+                ('level', models.PositiveIntegerField(default=1, verbose_name='Nível')),
+                ('hit_points', models.PositiveIntegerField(default=10, verbose_name='Pontos de Vida')),
+                ('mana', models.PositiveIntegerField(default=5, verbose_name='Mana')),
+                ('biography', models.TextField(blank=True, help_text='Um pouco sobre as motivações do herói.', verbose_name='História')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('owner', models.ForeignKey(blank=True, help_text='Usuário responsável pela ficha, quando autenticado.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='rpg_characters', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'verbose_name': 'Personagem',
+                'verbose_name_plural': 'Personagens',
+                'ordering': ['name'],
+            },
+        ),
+        migrations.CreateModel(
+            name='Mission',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=140, verbose_name='Nome')),
+                ('description', models.TextField(verbose_name='Descrição')),
+                ('difficulty', models.CharField(choices=[('easy', 'Fácil'), ('standard', 'Normal'), ('heroic', 'Heróica'), ('legendary', 'Lendária')], default='standard', max_length=12, verbose_name='Dificuldade')),
+                ('minimum_level', models.PositiveIntegerField(default=1, verbose_name='Nível mínimo')),
+                ('success_rate', models.PositiveIntegerField(default=70, help_text='Probabilidade base antes de bônus.', verbose_name='Chance de sucesso (%)')),
+                ('experience_reward', models.PositiveIntegerField(default=50, verbose_name='Experiência')),
+                ('gold_reward', models.PositiveIntegerField(default=30, verbose_name='Ouro')),
+            ],
+            options={
+                'verbose_name': 'Missão',
+                'verbose_name_plural': 'Missões',
+                'ordering': ['minimum_level', 'name'],
+            },
+        ),
+        migrations.CreateModel(
+            name='TrainingBot',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=120, verbose_name='Nome')),
+                ('description', models.TextField(verbose_name='Descrição')),
+                ('power_rating', models.PositiveIntegerField(default=5, verbose_name='Nível de poder')),
+                ('experience_reward', models.PositiveIntegerField(default=20, verbose_name='Experiência')),
+                ('gold_reward', models.PositiveIntegerField(default=10, verbose_name='Ouro')),
+            ],
+            options={
+                'verbose_name': 'Autômato de treino',
+                'verbose_name_plural': 'Autômatos de treino',
+                'ordering': ['power_rating'],
+            },
+        ),
+        migrations.CreateModel(
+            name='Battle',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('log', models.TextField(verbose_name='Relato da batalha')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('is_training', models.BooleanField(default=False, verbose_name='Treino')),
+                ('bot', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='battles', to='rpg.trainingbot')),
+                ('challenger', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='battles_as_challenger', to='rpg.character')),
+                ('opponent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='battles_as_opponent', to='rpg.character')),
+                ('winner', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='battles_won', to='rpg.character')),
+            ],
+            options={
+                'verbose_name': 'Batalha',
+                'verbose_name_plural': 'Batalhas',
+                'ordering': ['-created_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='MissionAttempt',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('success', models.BooleanField(default=False, verbose_name='Sucesso')),
+                ('summary', models.TextField(verbose_name='Resumo')),
+                ('experience_earned', models.PositiveIntegerField(default=0, verbose_name='Experiência recebida')),
+                ('gold_earned', models.PositiveIntegerField(default=0, verbose_name='Ouro recebido')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('character', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='mission_attempts', to='rpg.character')),
+                ('mission', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='attempts', to='rpg.mission')),
+            ],
+            options={
+                'verbose_name': 'Conclusão de missão',
+                'verbose_name_plural': 'Conclusões de missão',
+                'ordering': ['-created_at'],
+            },
+        ),
+    ]

--- a/rpg/migrations/0002_default_content.py
+++ b/rpg/migrations/0002_default_content.py
@@ -1,0 +1,99 @@
+# Default playable content for the RPG module.
+
+# Django
+from django.db import migrations
+
+
+def create_content(apps, schema_editor):
+    Mission = apps.get_model('rpg', 'Mission')
+    TrainingBot = apps.get_model('rpg', 'TrainingBot')
+
+    missions = [
+        {
+            'name': 'Resgatar o Mensageiro',
+            'description': 'Um emissário foi capturado por bandidos. Localize o esconderijo e traga-o com vida.',
+            'difficulty': 'standard',
+            'minimum_level': 1,
+            'success_rate': 75,
+            'experience_reward': 80,
+            'gold_reward': 60,
+        },
+        {
+            'name': 'Sombras em Ilyndor',
+            'description': 'Criaturas etéreas rondam as catacumbas da cidade. Precisa-se de coragem para selar o portal.',
+            'difficulty': 'heroic',
+            'minimum_level': 3,
+            'success_rate': 65,
+            'experience_reward': 140,
+            'gold_reward': 120,
+        },
+        {
+            'name': 'O Tesouro Afundado',
+            'description': 'Uma embarcação antiga reapareceu na costa. Explore-a e recupere artefatos antes que afunde novamente.',
+            'difficulty': 'legendary',
+            'minimum_level': 5,
+            'success_rate': 50,
+            'experience_reward': 220,
+            'gold_reward': 250,
+        },
+    ]
+
+    for mission in missions:
+        Mission.objects.get_or_create(name=mission['name'], defaults=mission)
+
+    bots = [
+        {
+            'name': 'Maniquim de Madeira',
+            'description': 'Ideal para aprender os fundamentos de combate.',
+            'power_rating': 4,
+            'experience_reward': 30,
+            'gold_reward': 15,
+        },
+        {
+            'name': 'Guardião Arcano',
+            'description': 'Projeta barreiras mágicas e dispara rajadas de energia.',
+            'power_rating': 9,
+            'experience_reward': 70,
+            'gold_reward': 40,
+        },
+        {
+            'name': 'Colosso Mecânico',
+            'description': 'Uma máquina pesada focada em resistência e força bruta.',
+            'power_rating': 14,
+            'experience_reward': 120,
+            'gold_reward': 80,
+        },
+    ]
+
+    for bot in bots:
+        TrainingBot.objects.get_or_create(name=bot['name'], defaults=bot)
+
+
+def remove_content(apps, schema_editor):
+    Mission = apps.get_model('rpg', 'Mission')
+    TrainingBot = apps.get_model('rpg', 'TrainingBot')
+
+    mission_names = [
+        'Resgatar o Mensageiro',
+        'Sombras em Ilyndor',
+        'O Tesouro Afundado',
+    ]
+    bot_names = [
+        'Maniquim de Madeira',
+        'Guardião Arcano',
+        'Colosso Mecânico',
+    ]
+
+    Mission.objects.filter(name__in=mission_names).delete()
+    TrainingBot.objects.filter(name__in=bot_names).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rpg', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_content, remove_content),
+    ]

--- a/rpg/models.py
+++ b/rpg/models.py
@@ -1,0 +1,255 @@
+"""Domain models for the browser based table-top RPG experience."""
+
+# Python standard library
+from __future__ import annotations
+import math
+import random
+from dataclasses import dataclass
+
+# Django
+from django.contrib.auth import get_user_model
+from django.db import models
+
+User = get_user_model()
+
+
+class Character(models.Model):
+    """Represents the hero sheet created by a player."""
+
+    owner = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='rpg_characters',
+        help_text='Usuário responsável pela ficha, quando autenticado.',
+    )
+    name = models.CharField('Nome', max_length=120)
+    concept = models.CharField(
+        'Conceito', max_length=120, help_text='Resumo rápido do personagem.'
+    )
+    origin = models.CharField(
+        'Origem', max_length=120, blank=True, help_text='Cidade, clã ou organização.'
+    )
+    archetype = models.CharField(
+        'Arquétipo', max_length=80, help_text='Classe ou função dentro do grupo.'
+    )
+    strength = models.PositiveIntegerField('Força', default=1)
+    agility = models.PositiveIntegerField('Agilidade', default=1)
+    intellect = models.PositiveIntegerField('Intelecto', default=1)
+    spirit = models.PositiveIntegerField('Espírito', default=1)
+    vitality = models.PositiveIntegerField('Vitalidade', default=1)
+    experience = models.PositiveIntegerField('Experiência', default=0)
+    gold = models.PositiveIntegerField('Ouro', default=0)
+    level = models.PositiveIntegerField('Nível', default=1)
+    hit_points = models.PositiveIntegerField('Pontos de Vida', default=10)
+    mana = models.PositiveIntegerField('Mana', default=5)
+    biography = models.TextField(
+        'História', blank=True, help_text='Um pouco sobre as motivações do herói.'
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ['name']
+        verbose_name = 'Personagem'
+        verbose_name_plural = 'Personagens'
+
+    def __str__(self) -> str:
+        return self.name
+
+    @property
+    def attribute_total(self) -> int:
+        return self.strength + self.agility + self.intellect + self.spirit + self.vitality
+
+    @property
+    def combat_power(self) -> int:
+        base = self.attribute_total + (self.level * 3)
+        return base + self.hit_points + self.mana
+
+    def gain_rewards(self, xp: int, gold: int) -> None:
+        self.experience = models.F('experience') + xp
+        self.gold = models.F('gold') + gold
+        self.save(update_fields=['experience', 'gold'])
+        self.refresh_from_db(fields=['experience', 'gold'])
+        self.recalculate_level()
+
+    def recalculate_level(self, *, auto_save: bool = True) -> None:
+        new_level = max(1, math.floor(self.experience / 100) + 1)
+        if new_level != self.level:
+            self.level = new_level
+            if auto_save and self.pk:
+                self.save(update_fields=['level'])
+
+
+class Mission(models.Model):
+    """Story driven activities that characters can tackle for rewards."""
+
+    DIFFICULTY_CHOICES = (
+        ('easy', 'Fácil'),
+        ('standard', 'Normal'),
+        ('heroic', 'Heróica'),
+        ('legendary', 'Lendária'),
+    )
+
+    name = models.CharField('Nome', max_length=140)
+    description = models.TextField('Descrição')
+    difficulty = models.CharField(
+        'Dificuldade', max_length=12, choices=DIFFICULTY_CHOICES, default='standard'
+    )
+    minimum_level = models.PositiveIntegerField('Nível mínimo', default=1)
+    success_rate = models.PositiveIntegerField(
+        'Chance de sucesso (%)', default=70, help_text='Probabilidade base antes de bônus.'
+    )
+    experience_reward = models.PositiveIntegerField('Experiência', default=50)
+    gold_reward = models.PositiveIntegerField('Ouro', default=30)
+
+    class Meta:
+        ordering = ['minimum_level', 'name']
+        verbose_name = 'Missão'
+        verbose_name_plural = 'Missões'
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class MissionAttempt(models.Model):
+    """Keeps track of mission outcomes for characters."""
+
+    mission = models.ForeignKey(Mission, on_delete=models.CASCADE, related_name='attempts')
+    character = models.ForeignKey(
+        Character, on_delete=models.CASCADE, related_name='mission_attempts'
+    )
+    success = models.BooleanField('Sucesso', default=False)
+    summary = models.TextField('Resumo')
+    experience_earned = models.PositiveIntegerField('Experiência recebida', default=0)
+    gold_earned = models.PositiveIntegerField('Ouro recebido', default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-created_at']
+        verbose_name = 'Conclusão de missão'
+        verbose_name_plural = 'Conclusões de missão'
+
+    def __str__(self) -> str:
+        result = 'sucesso' if self.success else 'falha'
+        return f"{self.character} em {self.mission} ({result})"
+
+
+class TrainingBot(models.Model):
+    """NPC opponents used for practice sessions."""
+
+    name = models.CharField('Nome', max_length=120)
+    description = models.TextField('Descrição')
+    power_rating = models.PositiveIntegerField('Nível de poder', default=5)
+    experience_reward = models.PositiveIntegerField('Experiência', default=20)
+    gold_reward = models.PositiveIntegerField('Ouro', default=10)
+
+    class Meta:
+        ordering = ['power_rating']
+        verbose_name = 'Autômato de treino'
+        verbose_name_plural = 'Autômatos de treino'
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class Battle(models.Model):
+    """Represents both PVP and training encounters."""
+
+    challenger = models.ForeignKey(
+        Character, on_delete=models.CASCADE, related_name='battles_as_challenger'
+    )
+    opponent = models.ForeignKey(
+        Character,
+        on_delete=models.CASCADE,
+        related_name='battles_as_opponent',
+        null=True,
+        blank=True,
+    )
+    bot = models.ForeignKey(
+        TrainingBot,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='battles',
+    )
+    winner = models.ForeignKey(
+        Character,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='battles_won',
+    )
+    log = models.TextField('Relato da batalha')
+    created_at = models.DateTimeField(auto_now_add=True)
+    is_training = models.BooleanField('Treino', default=False)
+
+    class Meta:
+        ordering = ['-created_at']
+        verbose_name = 'Batalha'
+        verbose_name_plural = 'Batalhas'
+
+    def __str__(self) -> str:
+        target = self.bot if self.is_training else self.opponent
+        return f"{self.challenger} vs {target}"
+
+
+@dataclass
+class BattleResult:
+    winner: Character | None
+    loser: Character | None
+    battle_log: str
+    challenger_roll: int
+    opponent_roll: int
+
+
+def resolve_duel(challenger: Character, opponent: Character) -> BattleResult:
+    """Simple combat resolution between two characters."""
+
+    challenger_power = challenger.combat_power
+    opponent_power = opponent.combat_power
+    challenger_roll = random.randint(1, 20) + challenger_power
+    opponent_roll = random.randint(1, 20) + opponent_power
+
+    if challenger_roll == opponent_roll:
+        log = (
+            f"Ambos os heróis travam um duelo equilibrado! "
+            f"Empate técnico com {challenger_roll} pontos."
+        )
+        return BattleResult(None, None, log, challenger_roll, opponent_roll)
+
+    if challenger_roll > opponent_roll:
+        log = (
+            f"{challenger.name} supera {opponent.name} com {challenger_roll} contra {opponent_roll}. "
+            "O campeão celebra a vitória!"
+        )
+        return BattleResult(challenger, opponent, log, challenger_roll, opponent_roll)
+
+    log = (
+        f"{opponent.name} domina o campo ao alcançar {opponent_roll} pontos, "
+        f"superando {challenger.name}. Vitória incontestável!"
+    )
+    return BattleResult(opponent, challenger, log, challenger_roll, opponent_roll)
+
+
+def resolve_training(challenger: Character, bot: TrainingBot) -> BattleResult:
+    """Combat resolution versus an automated training bot."""
+
+    challenger_power = challenger.combat_power
+    bot_power = bot.power_rating * 8
+    challenger_roll = random.randint(1, 20) + challenger_power
+    opponent_roll = random.randint(1, 20) + bot_power
+
+    if challenger_roll >= opponent_roll:
+        log = (
+            f"{challenger.name} vence o autômato {bot.name}! "
+            f"{challenger_roll} contra {opponent_roll}."
+        )
+        return BattleResult(challenger, None, log, challenger_roll, opponent_roll)
+
+    log = (
+        f"O autômato {bot.name} desestabiliza {challenger.name}, "
+        f"obtendo {opponent_roll} contra {challenger_roll}."
+    )
+    return BattleResult(None, challenger, log, challenger_roll, opponent_roll)

--- a/rpg/urls.py
+++ b/rpg/urls.py
@@ -1,0 +1,22 @@
+"""URL routing for the RPG features."""
+
+# Django
+from django.urls import path
+
+# Local
+from . import views
+
+app_name = 'rpg'
+
+urlpatterns = [
+    path('', views.home, name='home'),
+    path('fichas/', views.character_list, name='character_list'),
+    path('fichas/nova/', views.character_create, name='character_create'),
+    path('fichas/<int:pk>/', views.character_detail, name='character_detail'),
+    path('duelos/', views.start_duel, name='start_duel'),
+    path('batalhas/<int:pk>/', views.battle_log, name='battle_log'),
+    path('missoes/', views.mission_list, name='mission_list'),
+    path('missoes/<int:pk>/tentar/', views.attempt_mission, name='attempt_mission'),
+    path('missoes/resultados/<int:pk>/', views.mission_result, name='mission_result'),
+    path('treinos/', views.training_ground, name='training_ground'),
+]

--- a/rpg/views.py
+++ b/rpg/views.py
@@ -1,0 +1,235 @@
+"""Views responsible for orchestrating the RPG experience."""
+
+# Python standard library
+import random
+
+# Django
+from django.contrib import messages
+from django.db import transaction
+from django.db.models import Q
+from django.shortcuts import get_object_or_404, redirect, render
+
+# Local
+from .forms import CharacterForm, DuelForm, MissionAttemptForm, TrainingBattleForm
+from .models import (
+    Battle,
+    Character,
+    Mission,
+    MissionAttempt,
+    TrainingBot,
+    resolve_duel,
+    resolve_training,
+)
+
+
+def home(request):
+    """Overview of the RPG hub with quick access to all features."""
+
+    latest_characters = Character.objects.order_by('-created_at')[:6]
+    recent_battles = (
+        Battle.objects.select_related('challenger', 'opponent', 'bot', 'winner')
+        .all()[:5]
+    )
+    missions = Mission.objects.all()
+    bots = TrainingBot.objects.all()
+
+    context = {
+        'latest_characters': latest_characters,
+        'recent_battles': recent_battles,
+        'missions': missions,
+        'bots': bots,
+    }
+    return render(request, 'rpg/home.html', context)
+
+
+def character_list(request):
+    characters = Character.objects.all()
+    return render(request, 'rpg/character_list.html', {'characters': characters})
+
+
+def character_create(request):
+    if request.method == 'POST':
+        form = CharacterForm(request.POST)
+        if form.is_valid():
+            character = form.save(commit=False)
+            if request.user.is_authenticated:
+                character.owner = request.user
+            character.save()
+            messages.success(request, 'Ficha criada com sucesso! Prepare-se para a aventura.')
+            return redirect('rpg:character_detail', pk=character.pk)
+        messages.error(request, 'Não foi possível criar a ficha. Verifique os dados informados.')
+    else:
+        form = CharacterForm()
+    return render(request, 'rpg/character_form.html', {'form': form})
+
+
+def character_detail(request, pk):
+    character = get_object_or_404(Character, pk=pk)
+    battle_history = (
+        Battle.objects.select_related('winner', 'opponent', 'bot')
+        .filter(Q(challenger=character) | Q(opponent=character))
+        .order_by('-created_at')[:10]
+    )
+    mission_attempts = character.mission_attempts.select_related('mission')[:10]
+    return render(
+        request,
+        'rpg/character_detail.html',
+        {
+            'character': character,
+            'battle_history': battle_history,
+            'mission_attempts': mission_attempts,
+        },
+    )
+
+
+def start_duel(request):
+    if Character.objects.count() < 2:
+        messages.info(request, 'Cadastre pelo menos dois personagens para iniciar um duelo.')
+        return redirect('rpg:character_create')
+
+    if request.method == 'POST':
+        form = DuelForm(request.POST)
+        if form.is_valid():
+            challenger = form.cleaned_data['challenger']
+            opponent = form.cleaned_data['opponent']
+            with transaction.atomic():
+                result = resolve_duel(challenger, opponent)
+                battle = Battle.objects.create(
+                    challenger=challenger,
+                    opponent=opponent,
+                    winner=result.winner,
+                    log=result.battle_log,
+                )
+                if result.winner:
+                    xp_reward = 80
+                    gold_reward = 45
+                    result.winner.gain_rewards(xp_reward, gold_reward)
+                    messages.success(
+                        request,
+                        f"{result.winner.name} recebeu {xp_reward} XP e {gold_reward} moedas pela vitória!",
+                    )
+                else:
+                    for hero in (challenger, opponent):
+                        hero.gain_rewards(30, 10)
+                    messages.info(
+                        request,
+                        'O duelo terminou em empate épico! Ambos receberam experiência pelo esforço.',
+                    )
+            return redirect('rpg:battle_log', pk=battle.pk)
+        messages.error(request, 'Não foi possível iniciar o duelo. Revise a ficha selecionada.')
+    else:
+        form = DuelForm()
+    return render(request, 'rpg/battle_form.html', {'form': form})
+
+
+def battle_log(request, pk):
+    battle = get_object_or_404(
+        Battle.objects.select_related('challenger', 'opponent', 'bot', 'winner'), pk=pk
+    )
+    return render(request, 'rpg/battle_detail.html', {'battle': battle})
+
+
+def mission_list(request):
+    missions = Mission.objects.all()
+    return render(request, 'rpg/mission_list.html', {'missions': missions})
+
+
+def attempt_mission(request, pk):
+    mission = get_object_or_404(Mission, pk=pk)
+    if request.method == 'POST':
+        form = MissionAttemptForm(mission, request.POST)
+        if form.is_valid():
+            character = form.cleaned_data['character']
+            chance_bonus = character.attribute_total // 2
+            success_threshold = min(95, mission.success_rate + chance_bonus)
+            roll = random.randint(1, 100)
+            success = roll <= success_threshold
+            summary = (
+                f"{character.name} tentou a missão com uma chance total de {success_threshold}% (dado {roll})."
+                f" Resultado: {'sucesso' if success else 'falha'}."
+            )
+            xp = mission.experience_reward if success else mission.experience_reward // 4
+            gold = mission.gold_reward if success else mission.gold_reward // 4
+            with transaction.atomic():
+                attempt = MissionAttempt.objects.create(
+                    mission=mission,
+                    character=character,
+                    success=success,
+                    summary=summary,
+                    experience_earned=xp,
+                    gold_earned=gold,
+                )
+                character.gain_rewards(xp, gold)
+            if success:
+                messages.success(
+                    request,
+                    f"Missão concluída! {character.name} ganhou {xp} XP e {gold} moedas.",
+                )
+            else:
+                messages.warning(
+                    request,
+                    f"A missão falhou, mas {character.name} aprendeu algo e ganhou {xp} XP.",
+                )
+            return redirect('rpg:mission_result', pk=attempt.pk)
+        messages.error(request, 'Selecione um personagem apto para realizar a missão.')
+    else:
+        form = MissionAttemptForm(mission)
+    return render(
+        request,
+        'rpg/mission_attempt.html',
+        {
+            'mission': mission,
+            'form': form,
+        },
+    )
+
+
+def mission_result(request, pk):
+    attempt = get_object_or_404(
+        MissionAttempt.objects.select_related('mission', 'character'), pk=pk
+    )
+    return render(request, 'rpg/mission_result.html', {'attempt': attempt})
+
+
+def training_ground(request):
+    if not Character.objects.exists():
+        messages.info(request, 'Cadastre um personagem antes de iniciar os treinamentos.')
+        return redirect('rpg:character_create')
+
+    if request.method == 'POST':
+        form = TrainingBattleForm(request.POST)
+        if form.is_valid():
+            character = form.cleaned_data['character']
+            bot = form.cleaned_data['bot']
+            with transaction.atomic():
+                result = resolve_training(character, bot)
+                battle = Battle.objects.create(
+                    challenger=character,
+                    opponent=None,
+                    bot=bot,
+                    is_training=True,
+                    winner=result.winner,
+                    log=result.battle_log,
+                )
+                if result.winner == character:
+                    character.gain_rewards(bot.experience_reward, bot.gold_reward)
+                    messages.success(
+                        request,
+                        f"Treino concluído! {character.name} ganhou {bot.experience_reward} XP e {bot.gold_reward} moedas.",
+                    )
+                else:
+                    character.gain_rewards(bot.experience_reward // 3, bot.gold_reward // 3)
+                    messages.warning(
+                        request,
+                        'Derrota! Use os ensinamentos para melhorar seus atributos.',
+                    )
+            return redirect('rpg:battle_log', pk=battle.pk)
+        messages.error(request, 'Não foi possível iniciar o treino. Corrija os dados e tente novamente.')
+    else:
+        form = TrainingBattleForm()
+    trainings = TrainingBot.objects.all()
+    return render(
+        request,
+        'rpg/training_ground.html',
+        {'form': form, 'trainings': trainings},
+    )

--- a/templates/base_page.html
+++ b/templates/base_page.html
@@ -16,6 +16,7 @@
 
     <!-- Stylesheet -->
     <link rel="stylesheet" href="{% static 'site.css' %}">
+    {% block extra_css %}{% endblock %}
 
   </head>
 
@@ -54,5 +55,6 @@
     <script src="{% static 'js/plugins/plugins.js' %}"></script>
     <!-- Active js -->
     <script src="{% static 'js/active.js' %}"></script>
+    {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/templates/partials/menu.html
+++ b/templates/partials/menu.html
@@ -66,11 +66,13 @@
                 {% if user.is_authenticated %}
                   <li><a href="{% url 'index' %}">Home</a></li>
                   <li><a href="{% url 'dashboard' %}">Minhas receitas</a></li>
+                  <li><a href="{% url 'rpg:home' %}">RPG de Mesa</a></li>
                   <li><a href="{% url 'cria_receita' %}">Criar receita</a></li>
                   <li><a href="{% url 'logout' %}">Sair</a></li>
                 {% else %}
                   <li><a href="{% url 'cadastro' %}">Cadastro</a></li>
                   <li><a href="{% url 'login' %}">Login</a></li>
+                  <li><a href="{% url 'rpg:home' %}">RPG de Mesa</a></li>
                 {% endif %}
               </ul>
 

--- a/templates/rpg/battle_detail.html
+++ b/templates/rpg/battle_detail.html
@@ -1,0 +1,38 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <h1>Relato da batalha</h1>
+    <article class="rpg-card">
+      <p class="rpg-muted">Registrado em {{ battle.created_at|date:'d/m/Y H:i' }}</p>
+      <p>
+        <strong>{{ battle.challenger.name }}</strong>
+        enfrentou
+        {% if battle.is_training %}
+          o autômato <strong>{{ battle.bot.name }}</strong>
+        {% else %}
+          <strong>{{ battle.opponent.name }}</strong>
+        {% endif %}.
+      </p>
+      <p>{{ battle.log }}</p>
+      <p>
+        {% if battle.winner %}
+          <strong>Vitória:</strong> {{ battle.winner.name }}
+        {% else %}
+          <strong>Resultado:</strong> Empate
+        {% endif %}
+      </p>
+      <div class="rpg-actions">
+        <a class="rpg-btn" href="{% url 'rpg:start_duel' %}">Novo duelo</a>
+        <a class="rpg-btn" href="{% url 'rpg:home' %}">Voltar ao salão</a>
+      </div>
+    </article>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/battle_form.html
+++ b/templates/rpg/battle_form.html
@@ -1,0 +1,32 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <h1>Organizar duelo</h1>
+    <p class="rpg-muted">Selecione dois personagens para resolver uma batalha automática.</p>
+    <form method="post" class="rpg-form">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="rpg-form-grid">
+        {% for field in form %}
+          <div class="rpg-field">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field }}
+            {% if field.help_text %}<small class="rpg-muted">{{ field.help_text }}</small>{% endif %}
+            {% for error in field.errors %}
+              <div class="rpg-error">{{ error }}</div>
+            {% endfor %}
+          </div>
+        {% endfor %}
+      </div>
+      <button class="rpg-btn" type="submit">Iniciar duelo</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/character_detail.html
+++ b/templates/rpg/character_detail.html
@@ -1,0 +1,89 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <header class="rpg-header">
+      <div>
+        <h1>{{ character.name }}</h1>
+        <p class="rpg-muted">{{ character.archetype }} • Nível {{ character.level }}</p>
+      </div>
+      <a class="rpg-btn" href="{% url 'rpg:start_duel' %}">Desafiar em duelo</a>
+    </header>
+
+    <div class="rpg-split">
+      <article class="rpg-card">
+        <h2>Ficha técnica</h2>
+        <ul class="rpg-attributes">
+          <li><strong>Conceito:</strong> {{ character.concept }}</li>
+          <li><strong>Origem:</strong> {{ character.origin|default:'—' }}</li>
+          <li><strong>Força:</strong> {{ character.strength }}</li>
+          <li><strong>Agilidade:</strong> {{ character.agility }}</li>
+          <li><strong>Intelecto:</strong> {{ character.intellect }}</li>
+          <li><strong>Espírito:</strong> {{ character.spirit }}</li>
+          <li><strong>Vitalidade:</strong> {{ character.vitality }}</li>
+          <li><strong>Pontos de Vida:</strong> {{ character.hit_points }}</li>
+          <li><strong>Mana:</strong> {{ character.mana }}</li>
+        </ul>
+        <p><strong>Biografia:</strong> {{ character.biography|default:'Sem registros por enquanto.' }}</p>
+      </article>
+      <article class="rpg-card">
+        <h2>Progresso</h2>
+        <p><strong>Experiência:</strong> {{ character.experience }} XP</p>
+        <p><strong>Ouro:</strong> {{ character.gold }} moedas</p>
+        <p><strong>Poder de combate:</strong> {{ character.combat_power }}</p>
+        <p class="rpg-muted">Criado em {{ character.created_at|date:'d/m/Y H:i' }}</p>
+      </article>
+    </div>
+
+    <div class="rpg-split">
+      <section>
+        <h2>Histórico de batalhas</h2>
+        {% if battle_history %}
+          <ul class="rpg-list">
+            {% for battle in battle_history %}
+              <li>
+                {% if battle.is_training %}
+                  Treino contra {{ battle.bot.name }}
+                {% else %}
+                  Duelo com {% if battle.challenger == character %}{{ battle.opponent.name }}{% else %}{{ battle.challenger.name }}{% endif %}
+                {% endif %}
+                —
+                {% if battle.winner %}
+                  Vitória de {{ battle.winner.name }}
+                {% else %}
+                  Empate
+                {% endif %}
+                <a class="rpg-inline-link" href="{% url 'rpg:battle_log' battle.pk %}">ver detalhes</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="rpg-muted">Nenhuma batalha registrada ainda.</p>
+        {% endif %}
+      </section>
+      <section>
+        <h2>Missões recentes</h2>
+        {% if mission_attempts %}
+          <ul class="rpg-list">
+            {% for attempt in mission_attempts %}
+              <li>
+                {{ attempt.mission.name }} — {% if attempt.success %}Sucesso{% else %}Falha{% endif %}
+                <span class="rpg-muted">(+{{ attempt.experience_earned }} XP)</span>
+                <a class="rpg-inline-link" href="{% url 'rpg:mission_result' attempt.pk %}">ver relato</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="rpg-muted">Em busca de aventuras. Conclua uma missão para iniciar o histórico.</p>
+        {% endif %}
+      </section>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/character_form.html
+++ b/templates/rpg/character_form.html
@@ -1,0 +1,32 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <h1>Nova ficha de personagem</h1>
+    <p class="rpg-muted">Defina os atributos iniciais e a história do seu herói.</p>
+    <form method="post" class="rpg-form">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="rpg-form-grid">
+        {% for field in form %}
+          <div class="rpg-field">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field }}
+            {% if field.help_text %}<small class="rpg-muted">{{ field.help_text }}</small>{% endif %}
+            {% for error in field.errors %}
+              <div class="rpg-error">{{ error }}</div>
+            {% endfor %}
+          </div>
+        {% endfor %}
+      </div>
+      <button class="rpg-btn" type="submit">Salvar ficha</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/character_list.html
+++ b/templates/rpg/character_list.html
@@ -1,0 +1,41 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <header class="rpg-header">
+      <div>
+        <h1>Personagens cadastrados</h1>
+        <p class="rpg-muted">Explore as fichas disponíveis para montar grupos e partidas.</p>
+      </div>
+      <a class="rpg-btn" href="{% url 'rpg:character_create' %}">Criar nova ficha</a>
+    </header>
+
+    {% if characters %}
+      <div class="rpg-grid">
+        {% for character in characters %}
+          <article class="rpg-card">
+            <h2>{{ character.name }}</h2>
+            <p class="rpg-muted">{{ character.archetype }} • Nível {{ character.level }}</p>
+            <ul class="rpg-attributes">
+              <li><strong>Força:</strong> {{ character.strength }}</li>
+              <li><strong>Agilidade:</strong> {{ character.agility }}</li>
+              <li><strong>Intelecto:</strong> {{ character.intellect }}</li>
+              <li><strong>Espírito:</strong> {{ character.spirit }}</li>
+              <li><strong>Vitalidade:</strong> {{ character.vitality }}</li>
+            </ul>
+            <a class="rpg-link" href="{% url 'rpg:character_detail' character.pk %}">Detalhes</a>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="rpg-muted">Sem fichas cadastradas por enquanto. Clique em "Criar nova ficha" para começar.</p>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/home.html
+++ b/templates/rpg/home.html
@@ -1,0 +1,110 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-hero">
+  <div class="container">
+    <h1>Crie sua aventura</h1>
+    <p>
+      Monte fichas de heróis, desafie amigos em batalhas JxJ e participe de missões
+      narrativas diretamente do navegador.
+    </p>
+    <div class="rpg-actions">
+      <a class="rpg-btn" href="{% url 'rpg:character_create' %}">Criar ficha</a>
+      <a class="rpg-btn" href="{% url 'rpg:start_duel' %}">Iniciar duelo</a>
+      <a class="rpg-btn" href="{% url 'rpg:mission_list' %}">Explorar missões</a>
+    </div>
+  </div>
+</section>
+
+<section class="rpg-section">
+  <div class="container">
+    <h2>Heróis prontos para agir</h2>
+    {% if latest_characters %}
+      <div class="rpg-grid">
+        {% for character in latest_characters %}
+          <article class="rpg-card">
+            <h3>{{ character.name }}</h3>
+            <p class="rpg-muted">{{ character.archetype }} • Nível {{ character.level }}</p>
+            <p>{{ character.concept }}</p>
+            <a class="rpg-link" href="{% url 'rpg:character_detail' character.pk %}">Ver ficha</a>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="rpg-muted">Nenhum personagem cadastrado ainda. Que tal criar o primeiro?</p>
+    {% endif %}
+  </div>
+</section>
+
+<section class="rpg-section alt">
+  <div class="container">
+    <h2>Últimas batalhas</h2>
+    {% if recent_battles %}
+      <ul class="rpg-list">
+        {% for battle in recent_battles %}
+          <li>
+            <strong>{{ battle.challenger.name }}</strong>
+            vs
+            {% if battle.is_training %}
+              autômato <strong>{{ battle.bot.name }}</strong>
+            {% else %}
+              <strong>{{ battle.opponent.name }}</strong>
+            {% endif %}
+            —
+            {% if battle.winner %}
+              vitória de {{ battle.winner.name }}
+            {% else %}
+              empate épico
+            {% endif %}
+            <a class="rpg-inline-link" href="{% url 'rpg:battle_log' battle.pk %}">ver relato</a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="rpg-muted">As arenas estão calmas. Organize um duelo para inaugurar as lutas!</p>
+    {% endif %}
+  </div>
+</section>
+
+<section class="rpg-section">
+  <div class="container">
+    <div class="rpg-split">
+      <div>
+        <h2>Quadro de missões</h2>
+        <p class="rpg-muted">Histórias rápidas para evoluir e ganhar recompensas.</p>
+        <ul class="rpg-list">
+          {% for mission in missions %}
+            <li>
+              <strong>{{ mission.name }}</strong>
+              — dificuldade {{ mission.get_difficulty_display }}
+              <a class="rpg-inline-link" href="{% url 'rpg:attempt_mission' mission.pk %}">participar</a>
+            </li>
+          {% empty %}
+            <li class="rpg-muted">Ainda não há missões disponíveis.</li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div>
+        <h2>Autômatos de treino</h2>
+        <p class="rpg-muted">Enfrente oponentes controlados pela IA para testar estratégias.</p>
+        <ul class="rpg-list">
+          {% for bot in bots %}
+            <li>
+              <strong>{{ bot.name }}</strong>
+              — poder {{ bot.power_rating }}
+              <a class="rpg-inline-link" href="{% url 'rpg:training_ground' %}">treinar</a>
+            </li>
+          {% empty %}
+            <li class="rpg-muted">Cadastre autômatos de treino pelo painel administrativo.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/mission_attempt.html
+++ b/templates/rpg/mission_attempt.html
@@ -1,0 +1,32 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <h1>{{ mission.name }}</h1>
+    <p class="rpg-muted">Dificuldade {{ mission.get_difficulty_display }} • nível mínimo {{ mission.minimum_level }}</p>
+    <p>{{ mission.description }}</p>
+    <p>Recompensas: {{ mission.experience_reward }} XP • {{ mission.gold_reward }} moedas</p>
+    <form method="post" class="rpg-form">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      {% for field in form %}
+        <div class="rpg-field">
+          <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+          {{ field }}
+          {% if field.help_text %}<small class="rpg-muted">{{ field.help_text }}</small>{% endif %}
+          {% for error in field.errors %}
+            <div class="rpg-error">{{ error }}</div>
+          {% endfor %}
+        </div>
+      {% endfor %}
+      <button class="rpg-btn" type="submit">Iniciar missão</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/mission_list.html
+++ b/templates/rpg/mission_list.html
@@ -1,0 +1,31 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <h1>Missões disponíveis</h1>
+    <p class="rpg-muted">Escolha uma missão para seus personagens participarem.</p>
+    {% if missions %}
+      <div class="rpg-grid">
+        {% for mission in missions %}
+          <article class="rpg-card">
+            <h2>{{ mission.name }}</h2>
+            <p class="rpg-muted">Dificuldade {{ mission.get_difficulty_display }}</p>
+            <p>{{ mission.description }}</p>
+            <p class="rpg-muted">Nível mínimo: {{ mission.minimum_level }}</p>
+            <p>Recompensas: {{ mission.experience_reward }} XP • {{ mission.gold_reward }} moedas</p>
+            <a class="rpg-btn" href="{% url 'rpg:attempt_mission' mission.pk %}">Tentar missão</a>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="rpg-muted">Nenhuma missão cadastrada. Cadastre novas missões pelo painel administrativo.</p>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/mission_result.html
+++ b/templates/rpg/mission_result.html
@@ -1,0 +1,26 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <article class="rpg-card">
+      <h1>Relatório de missão</h1>
+      <p class="rpg-muted">{{ attempt.created_at|date:'d/m/Y H:i' }}</p>
+      <p><strong>Personagem:</strong> {{ attempt.character.name }}</p>
+      <p><strong>Missão:</strong> {{ attempt.mission.name }}</p>
+      <p><strong>Resultado:</strong> {% if attempt.success %}Sucesso{% else %}Falha{% endif %}</p>
+      <p>{{ attempt.summary }}</p>
+      <p>Recompensas: {{ attempt.experience_earned }} XP • {{ attempt.gold_earned }} moedas</p>
+      <div class="rpg-actions">
+        <a class="rpg-btn" href="{% url 'rpg:mission_list' %}">Explorar mais missões</a>
+        <a class="rpg-btn" href="{% url 'rpg:character_detail' attempt.character.pk %}">Ver ficha</a>
+      </div>
+    </article>
+  </div>
+</section>
+{% endblock %}

--- a/templates/rpg/training_ground.html
+++ b/templates/rpg/training_ground.html
@@ -1,0 +1,47 @@
+{% extends 'base_page.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'rpg.css' %}">
+{% endblock %}
+
+{% block content %}
+<section class="rpg-section">
+  <div class="container">
+    <h1>Arena de treinamento</h1>
+    <p class="rpg-muted">Selecione um autômato para testar suas habilidades antes de desafiar outros jogadores.</p>
+    <form method="post" class="rpg-form">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+      <div class="rpg-form-grid">
+        {% for field in form %}
+          <div class="rpg-field">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field }}
+            {% if field.help_text %}<small class="rpg-muted">{{ field.help_text }}</small>{% endif %}
+            {% for error in field.errors %}
+              <div class="rpg-error">{{ error }}</div>
+            {% endfor %}
+          </div>
+        {% endfor %}
+      </div>
+      <button class="rpg-btn" type="submit">Iniciar treino</button>
+    </form>
+
+    <h2>Autômatos disponíveis</h2>
+    {% if trainings %}
+      <ul class="rpg-list">
+        {% for bot in trainings %}
+          <li>
+            <strong>{{ bot.name }}</strong>
+            — poder {{ bot.power_rating }}
+            <span class="rpg-muted">Recompensa: {{ bot.experience_reward }} XP • {{ bot.gold_reward }} moedas</span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="rpg-muted">Nenhum autômato cadastrado no momento.</p>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new `rpg` Django app with models for characters, missions, training bots, and battles
- implement forms, views, URLs, and templates so players can create fichas, duel, run missions, and train against bots
- seed default missions/bots, introduce dedicated styling, and expose the hub through navigation updates

## Testing
- not run (Django missing from execution environment)


------
https://chatgpt.com/codex/tasks/task_e_6902022880788333bf89835981779085

## Summary by Sourcery

Introduce a new tabletop RPG Django app with character sheets, duels, missions, and training encounters fully integrated into the existing project.

New Features:
- Add rpg app with Character, Mission, TrainingBot, MissionAttempt, and Battle models plus combat resolution logic
- Provide views, forms, URLs, and templates for creating characters, running duels, attempting missions, and training against bots
- Seed default missions and training bots via data migrations

Enhancements:
- Integrate RPG hub into main navigation and update base templates to support extra CSS/JS blocks
- Introduce dedicated rpg.css for styling RPG components

Chores:
- Register RPG models in Django admin, configure the app in settings and URL routing